### PR TITLE
OTP 18.0 compatible

### DIFF
--- a/src/emqttc.erl
+++ b/src/emqttc.erl
@@ -55,7 +55,7 @@
 		msgid = 0 :: non_neg_integer(),
 		username  :: binary(),
 		password  :: binary(),
-		ref       :: dict() }).
+		ref       :: dict:dict() }).
 
 %%--------------------------------------------------------------------
 %% @doc start application


### PR DESCRIPTION
Hi!

I have made a little fix to remove this compile error:
>src/emqttc.erl:58: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
>ERROR: compile failed while processing /Users/assoulter/development/workspace/emqttc: rebar_abort