### PR TITLE
Add included_applications to .app.src

### DIFF
--- a/src/emqttc.app.src
+++ b/src/emqttc.app.src
@@ -32,5 +32,9 @@
         kernel,
         stdlib
     ]},
+    {included_applications, [
+        gen_logger,
+        getopt
+    ]},
     {env, []}
 ]}.


### PR DESCRIPTION
Exrm is a release manager for elixir that uses `relx` internally. It automatically includes everything in `applications` and `included_applications` in the release. Adding the dependencies of `emqttc` into its `included_applications` enables elixir projects using `emqttc` to generate a release with zero configuration, using `exrm`.