### PR TITLE
Fully support SSL Options

### DIFF
--- a/src/emqttc_socket.erl
+++ b/src/emqttc_socket.erl
@@ -53,6 +53,8 @@
 -define(SSLOPTIONS, [{depth, 0}]).
 
 -record(ssl_socket, {tcp, ssl}).
+-record(sslsocket, {gen_tcp, pid}).
+-record(gen_tcp, { port, conn_type, unknown }).
 
 -type ssl_socket() :: #ssl_socket{}.
 
@@ -152,7 +154,8 @@ setopts(#ssl_socket{ssl = SslSocket}, Opts) ->
     Values  :: list().
 getstat(Socket, Stats) when is_port(Socket) ->
     inet:getstat(Socket, Stats);
-getstat(#ssl_socket{tcp = undefined, ssl = {sslsocket, {gen_tcp, Port, tls_connection, undefined}, _Pid}}, Stats) ->
+getstat(#ssl_socket{tcp = undefined, ssl = SSL}, Stats) ->
+    Port = SSL#sslsocket.gen_tcp#gen_tcp.port,
     inet:getstat(Port, Stats);
 getstat(#ssl_socket{tcp = Socket}, Stats) -> 
     inet:getstat(Socket, Stats).


### PR DESCRIPTION
I needed to provide ssloptions to the connect that include the following props:
      [{keyfile, "privateKey.pem"}, {certfile, "cert.pem"}]
With the way that you had originally designed it, I could not properly pass these values to the connecting.  I modified the way you were handling the ssl connection types to skip the gen_tcp:connect and instead use all options with the ssl:connect.

As a test source (and thus the name of the branch) I had been testing against the AWS IoT hub.  With these changes, this now supports connecting to the AWS IoT Hub as well as subscriptions and publishing.  I have yet to test other functionality.  

Unfortunately, the current testing that is implemented into the application is somewhat limited.
