### PR TITLE
Use new erlang Time API and include OTP 18.x in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 
 otp_release:
    - 17.0
+   - 18.0
+   - 18.2.1
 
 script: 
   - make

--- a/src/emqttc_protocol.erl
+++ b/src/emqttc_protocol.erl
@@ -29,6 +29,8 @@
 
 -include("emqttc_packet.hrl").
 
+-compile(nowarn_deprecated_function).
+
 %% State API
 -export([init/1, set_socket/2]).
 
@@ -121,9 +123,16 @@ init_willmsg([_Opt | Opts], State) ->
     init_willmsg(Opts, State).
 
 random_id() ->
-    % erlang 18.x
-    %random:seed(erlang:timestamp()),
-    random:seed(now()),
+    Now =
+        try
+            % erlang 18.x
+            erlang:timestamp()
+        catch
+            error:undef ->
+            % erlang 17.x
+                erlang:now()
+        end,
+    random:seed(Now),
     I1 = random:uniform(round(math:pow(2, 48))) - 1,
     I2 = random:uniform(round(math:pow(2, 32))) - 1,
     {ok, Host} = inet:gethostname(),


### PR DESCRIPTION
- use 18.x new Time API to replace erlang:now() (ballback to 17.x Time API if not exist)
- add OTP 18.x support in travis CI
