### PR TITLE
Use https for github dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,6 +23,6 @@
 {validate_app_modules, true}.
 
 {deps, [
-    {gen_logger, ".*", {git, "git://github.com/emqtt/gen_logger.git", {branch, "master"}}},
+    {gen_logger, ".*", {git, "https://github.com/emqtt/gen_logger.git", {branch, "master"}}},
     {getopt, "0.8.2", {git, "https://github.com/jcomellas/getopt.git", {branch, "master"}}}
 ]}.


### PR DESCRIPTION
HTTPS should be the preferred method to connect to github to avoid problems with firewalls, and also to prevent man-in-middle attacks.