### PR TITLE
Fix sync_subscribe spec

### DIFF
--- a/include/emqttc_packet.hrl
+++ b/include/emqttc_packet.hrl
@@ -43,6 +43,7 @@
 -define(QOS_0, 0).
 -define(QOS_1, 1).
 -define(QOS_2, 2).
+-define(QOS_UNAUTHORIZED, 128).
 
 -define(IS_QOS(I), (I >= ?QOS_0 andalso I =< ?QOS_2)).
 

--- a/src/emqttc.erl
+++ b/src/emqttc.erl
@@ -291,7 +291,7 @@ subscribe(Client, [{_Topic, _Qos} | _] = Topics) ->
 %% @doc Subscribe topic or topics and wait until suback received.
 %% @end
 %%------------------------------------------------------------------------------
--spec sync_subscribe(Client, Topics) -> {ok, mqtt_qos() | [mqtt_qos()]} when
+-spec sync_subscribe(Client, Topics) -> {ok, (mqtt_qos() | ?QOS_UNAUTHORIZED) | [mqtt_qos() | ?QOS_UNAUTHORIZED]} when
     Client    :: pid() | atom(),
     Topics    :: [{binary(), mqtt_qos()}] | {binary(), mqtt_qos()} | binary().
 sync_subscribe(Client, Topic) when is_binary(Topic) ->
@@ -321,7 +321,7 @@ subscribe(Client, Topic, Qos) when is_binary(Topic), (?IS_QOS(Qos) orelse is_ato
 %% @doc Subscribe Topic with QoS and wait until suback received.
 %% @end
 %%------------------------------------------------------------------------------
--spec sync_subscribe(Client, Topic, Qos) -> {ok, mqtt_qos()} when
+-spec sync_subscribe(Client, Topic, Qos) -> {ok, mqtt_qos() | ?QOS_UNAUTHORIZED} when
     Client    :: pid() | atom(),
     Topic     :: binary(),
     Qos       :: qos0 | qos1 | qos2 | mqtt_qos().


### PR DESCRIPTION
EMQTT will return the special QoS code 128 in case the subscriber has no authorization for the topic, but this case is not reflected in the current `sync_subscribe` specs.

This commit updates the sync_subscribe spec to take this into account.